### PR TITLE
Build with Qt 6

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ else
     export $(dbus-launch)
     #qdbusviewer &
     BUILD_ROOT=/home/florian/basyskom/build-compositor-Desktop-Debug
+	export QT_ENABLE_HIGHDPI_SCALING=0
 	export QT_SCREEN_SCALE_FACTORS=
 	export QT_AUTO_SCREEN_SCALE_FACTOR=0
 	mkdir -p $BUILD_ROOT/plugins/wayland-shell-integration

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -81,7 +81,11 @@ EmbeddedShellIntegration::createShellSurface(
 
 bool EmbeddedShellIntegration::initialize(
     QtWaylandClient::QWaylandDisplay *display) {
-  QWaylandShellIntegration::initialize(display);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QWaylandShellIntegration::initialize(display);
+#else
+    Q_UNUSED(display);
+#endif
   return m_shell->isActive();
 }
 

--- a/shellintegration/embeddedshellintegration.h
+++ b/shellintegration/embeddedshellintegration.h
@@ -10,7 +10,13 @@
 class EmbeddedShellSurface;
 class EmbeddedShell;
 
-class Q_WAYLAND_CLIENT_EXPORT EmbeddedShellIntegration
+class
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
+Q_WAYLAND_CLIENT_EXPORT
+#else
+Q_WAYLANDCLIENT_EXPORT
+#endif
+        EmbeddedShellIntegration
     : public QtWaylandClient::QWaylandShellIntegration {
   QMap<QtWaylandClient::QWaylandWindow *, EmbeddedShellSurface *> m_windows;
   QScopedPointer<EmbeddedShell> m_shell;

--- a/testclients/bottomclient/main.qml
+++ b/testclients/bottomclient/main.qml
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import QtQuick 2.15
-import EmbeddedShell 1.0
+import EmbeddedShell 1.0 as EmbeddedShell
 
-Window {
+EmbeddedShell.Window {
     id: window
     height: 48
     visible: true
     title: qsTr("Hello World")
     color: "grey"
-    anchor: Window.Anchor.Bottom
+    anchor: EmbeddedShell.Window.Anchor.Bottom
     margin: 48
 
     Row {

--- a/testclients/leftclient/main.qml
+++ b/testclients/leftclient/main.qml
@@ -62,7 +62,7 @@ Window {
                 width:32
                 height:32
                 onClicked: {
-                    var view =  window.createView();
+                    var view =  window.createView("New View", 0);
                     console.log("view:"+view);
                 }
                 Rectangle {

--- a/testclients/leftclient/main.qml
+++ b/testclients/leftclient/main.qml
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import QtQuick 2.15
-import EmbeddedShell 1.0
+import EmbeddedShell 1.0 as EmbeddedShell
 
-Window {
+EmbeddedShell.Window {
     id: window
     width: menu.visible ? menu.width : bar.width
     visible: true
     title: qsTr("Hello from LeftCLient")
-    anchor: Window.Anchor.Left
+    anchor: EmbeddedShell.Window.Anchor.Left
     color: "transparent"
     margin: 64
     Rectangle {

--- a/testclients/quickcenterclient/main.qml
+++ b/testclients/quickcenterclient/main.qml
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import QtQuick 2.15
-import EmbeddedShell 1.0
+import EmbeddedShell 1.0 as EmbeddedShell
 
-Window {
+EmbeddedShell.Window {
     id: window
     visible: true
     title: qsTr("Hello from CenterCLient")
-    anchor: Window.Anchor.Center
+    anchor: EmbeddedShell.Window.Anchor.Center
     color: "darkgray"
     width: 200
     height:200

--- a/testclients/rightclient/main.qml
+++ b/testclients/rightclient/main.qml
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import QtQuick 2.15
-import EmbeddedShell 1.0
+import EmbeddedShell 1.0 as EmbeddedShell
 
-Window {
+EmbeddedShell.Window {
     id: window
     width: menu.visible ? menu.width : bar.width
     visible: true
     title: qsTr("Hello World")
     color: "transparent"
-    anchor: Window.Anchor.Right
+    anchor: EmbeddedShell.Window.Anchor.Right
     margin: bar.width
 
     Rectangle {

--- a/testclients/topclient/main.qml
+++ b/testclients/topclient/main.qml
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import QtQuick 2.15
-import EmbeddedShell 1.0
+import EmbeddedShell 1.0 as EmbeddedShell
 
-Window {
+EmbeddedShell.Window {
     id: window
     height: menu.visible ? menu.height: bar.height
     visible: true
     title: qsTr("Hello World")
     color: "transparent"
-    anchor: Window.Anchor.Top
+    anchor: EmbeddedShell.Window.Anchor.Top
     margin: bar.height
 
     Rectangle {


### PR DESCRIPTION
This merge request allows building the embedded-compositor against Qt 6.

There is currently no drop-in replacement for the `FastBlur` component from `QtGraphicalEffects` used in the task switcher.