### PR TITLE
Clean-up DBus-related code

### DIFF
--- a/compositor.pro
+++ b/compositor.pro
@@ -7,7 +7,7 @@ SUBDIRS = shellintegration \
         testclients \
         systemd
 
-OTHER_FILES = run.sh protocol/*.xml .qmake.conf
+OTHER_FILES = run.sh protocol/*.xml dbus/*.xml .qmake.conf
 
 shellintegration.depends += embeddedplatform
 quickembeddedshellwindow.depends += embeddedplatform

--- a/compositor/compositor.pro
+++ b/compositor/compositor.pro
@@ -38,10 +38,15 @@ taskswitcher_adaptor.files = ../dbus/com.embeddedcompositor.taskswitcher.xml
 taskswitcher_adaptor.header_flags = -l TaskSwitcherInterface -i dbusinterface.h
 taskswitcher_adaptor.source_flags = -l TaskSwitcherInterface
 
+notifications_adaptor.files = ../dbus/org.freedesktop.Notifications.xml
+notifications_adaptor.header_flags = -l NotificationModel -i notificationmodel.h
+notifications_adaptor.source_flags = -l NotificationModel
+
 DBUS_ADAPTORS += \
     globaloverlay_adaptor \
     screen_adaptor \
-    taskswitcher_adaptor
+    taskswitcher_adaptor \
+    notifications_adaptor
 
 RESOURCES += qml.qrc
 

--- a/compositor/compositor.pro
+++ b/compositor/compositor.pro
@@ -25,6 +25,24 @@ OTHER_FILES += \
     qml/Notifications/Notifications.qml \
     qml/Notifications/Notification.qml
 
+# NOTE There appears to be no easy way to specify the parent class of qdbusxml2cpp through QMake.
+globaloverlay_adaptor.files = ../dbus/com.embeddedcompositor.globaloverlay.xml
+globaloverlay_adaptor.header_flags = -l GlobalOverlayInterface -i dbusinterface.h
+globaloverlay_adaptor.source_flags = -l GlobalOverlayInterface
+
+screen_adaptor.files = ../dbus/com.embeddedcompositor.screen.xml
+screen_adaptor.header_flags = -l CompositorScreenInterface -i dbusinterface.h
+screen_adaptor.source_flags = -l CompositorScreenInterface
+
+taskswitcher_adaptor.files = ../dbus/com.embeddedcompositor.taskswitcher.xml
+taskswitcher_adaptor.header_flags = -l TaskSwitcherInterface -i dbusinterface.h
+taskswitcher_adaptor.source_flags = -l TaskSwitcherInterface
+
+DBUS_ADAPTORS += \
+    globaloverlay_adaptor \
+    screen_adaptor \
+    taskswitcher_adaptor
+
 RESOURCES += qml.qrc
 
 target.path = /usr/bin

--- a/compositor/dbusinterface.h
+++ b/compositor/dbusinterface.h
@@ -4,95 +4,101 @@
 #define DBUSINTERFACE_H
 
 #include <QDBusConnection>
-#include <QDBusError>
+#include <QDBusContext>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QQmlParserStatus>
-#include <QTimer>
+
+Q_DECLARE_LOGGING_CATEGORY(compositorDBus)
 
 bool InitDbusConnection(QString serviceName);
 
-class TaskSwitcherInterface : public QObject, public QQmlParserStatus {
-  Q_OBJECT
-  Q_CLASSINFO("D-Bus Interface", "com.embeddedcompositor.taskswitcher")
-  bool m_valid = false;
+class DBusInterface : public QObject, public QQmlParserStatus, protected QDBusContext
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString interfaceName READ interfaceName CONSTANT)
+    Q_PROPERTY(QString objectPath READ objectPath CONSTANT)
+    Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
 
 public:
-  Q_INTERFACES(QQmlParserStatus)
-  TaskSwitcherInterface() {}
-  virtual ~TaskSwitcherInterface() override {}
+    ~DBusInterface() override = default;
 
-  Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
-  bool valid() const { return m_valid; }
+    QDBusConnection busConnection() const;
+    QString interfaceName() const;
+    QString objectPath() const;
 
-  // QQmlParserStatus interface
-  void classBegin() override {}
-  void componentComplete() override;
+    bool valid() const;
+    Q_SIGNAL void validChanged(bool valid);
 
-public slots:
-  Q_SCRIPTABLE void Open() { emit openRequested(); }
-  Q_SCRIPTABLE void Close() { emit closeRequested(); }
+protected:
+    DBusInterface(const QString &objectPath, QObject *parent = nullptr);
 
-signals:
-  void validChanged();
-  void openRequested();
-  void closeRequested();
-};
+    // QQmlParserStatus
+    void classBegin() override;
+    void componentComplete() override;
 
-class GlobalOverlayInterface : public QObject, public QQmlParserStatus {
-  Q_OBJECT
-  Q_CLASSINFO("D-Bus Interface", "com.embeddedcompositor.globaloverlay")
-  bool m_valid = false;
-
-public:
-  Q_INTERFACES(QQmlParserStatus)
-  GlobalOverlayInterface() {}
-  virtual ~GlobalOverlayInterface() override {}
-
-  Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
-  bool valid() const { return m_valid; }
-
-  // QQmlParserStatus interface
-  void classBegin() override {}
-  void componentComplete() override;
-
-public slots:
-  Q_SCRIPTABLE void Show(QString message) { emit showRequested(message); }
-  Q_SCRIPTABLE void Hide() { emit hideRequested(); }
-
-signals:
-  void validChanged();
-  void showRequested(QString message);
-  void hideRequested();
-};
-
-class CompositorScreenInterface : public QObject, public QQmlParserStatus {
-  Q_OBJECT
-  Q_CLASSINFO("D-Bus Interface", "com.embeddedcompositor.screen")
-  bool m_valid = false;
-
-public:
-  Q_INTERFACES(QQmlParserStatus)
-  CompositorScreenInterface();
-  virtual ~CompositorScreenInterface() override {}
-
-  Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
-  bool valid() const { return m_valid; }
-
-  // QQmlParserStatus interface
-  void classBegin() override {}
-  void componentComplete() override;
-
-  Q_PROPERTY(QString orientation READ orientation WRITE setOrientation NOTIFY
-                 orientationChanged)
-
-  const QString &orientation() const;
-  void setOrientation(const QString &newOrientation);
-
-signals:
-  void validChanged();
-  void orientationChanged(const QString &orientation);
+private Q_SLOTS:
+    void onPropertyChanged();
 
 private:
-  QString m_orientation = "0";
+    QString m_objectPath;
+    bool m_valid = false;
 };
+
+class TaskSwitcherInterface : public DBusInterface
+{
+    Q_OBJECT
+
+public:
+    TaskSwitcherInterface(QObject *parent = nullptr);
+    ~TaskSwitcherInterface() override = default;
+
+    // DBus
+    void Open();
+    void Close();
+
+Q_SIGNALS:
+    void openRequested();
+    void closeRequested();
+};
+
+class GlobalOverlayInterface : public DBusInterface
+{
+    Q_OBJECT
+
+public:
+    GlobalOverlayInterface(QObject *parent = nullptr);
+    ~GlobalOverlayInterface() override = default;
+
+    // DBus
+    void Show(const QString &message);
+    void Hide();
+
+Q_SIGNALS:
+    void showRequested(const QString &message);
+    void hideRequested();
+};
+
+class CompositorScreenInterface : public DBusInterface
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
+
+public:
+    CompositorScreenInterface(QObject *parent = nullptr);
+    ~CompositorScreenInterface() override = default;
+
+    QString orientation() const;
+    void setOrientation(const QString &orientation);
+
+Q_SIGNALS:
+    void orientationChanged(const QString &orientation);
+
+private:
+    QString m_orientation;
+};
+
 #endif // DBUSINTERFACE_H

--- a/compositor/main.cpp
+++ b/compositor/main.cpp
@@ -40,10 +40,6 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  qmlRegisterUncreatableType<NotificationData>("com.embeddedcompositor.dbus", 1,
-                                               0, "NotificationData",
-                                               "created from dbus data");
-
   qmlRegisterType<SortFilterProxyModel>("com.embeddedcompositor.utility", 1, 0,
                                         "SortFilterProxyModel");
 

--- a/compositor/notificationmodel.cpp
+++ b/compositor/notificationmodel.cpp
@@ -1,139 +1,246 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "notificationmodel.h"
+
 #include "dbus-selector.h"
+
 #include <QDBusConnection>
-#include <QDBusError>
-#include <QDBusMessage>
-#include <QDebug>
+
+#include <algorithm>
+
+#include "notifications_adaptor.h"
+
+Q_LOGGING_CATEGORY(compositorNotification, "compositor.notification")
 
 NotificationModel::NotificationModel(QObject *parent)
-    : QAbstractListModel(parent),
-      dbusInterface(new NotificationDbusInterface(this)),
-      connection(QDBusConnection::connectToBus(defaultBus,
-                                               NotificationDbusInterface::Name))
-
+    : QAbstractListModel(parent)
 {
-  connect(this, &QAbstractListModel::rowsInserted, this,
-          &NotificationModel::countChanged);
-  connect(this, &QAbstractListModel::rowsRemoved, this,
-          &NotificationModel::countChanged);
+    new NotificationsAdaptor(this);
+
+    connect(this, &NotificationModel::rowsInserted, this, &NotificationModel::countChanged);
+    connect(this, &NotificationModel::rowsRemoved, this, &NotificationModel::countChanged);
 }
 
-NotificationModel::~NotificationModel() {
-  qDeleteAll(m_data);
-  m_data.clear();
+void NotificationModel::classBegin()
+{
 }
 
-void NotificationModel::Add(NotificationData *data) {
-  beginInsertRows(QModelIndex(), rowCount(), rowCount());
-  m_data.append(data);
-  endInsertRows();
-  connect(data, &NotificationData::dismissed, this,
-          &NotificationModel::dismissed);
+void NotificationModel::componentComplete()
+{
+    auto connection = getBus();
+
+    if (!connection.registerObject(QStringLiteral("/org/freedesktop/Notifications"), this)) {
+        qCWarning(compositorNotification) << "Failed to register notifications object";
+        return;
+    }
+    if (!connection.registerService(QStringLiteral("org.freedesktop.Notifications"))) {
+        qCWarning(compositorNotification) << "Failed to register notifications service";
+        return;
+    }
+
+    m_valid = true;
+    Q_EMIT validChanged();
 }
 
-int NotificationModel::rowCount(const QModelIndex &parent) const {
-  Q_UNUSED(parent)
-  return m_data.count();
+bool NotificationModel::valid() const
+{
+    return m_valid;
 }
 
-QVariant NotificationModel::data(const QModelIndex &index, int role) const {
-  if (!index.isValid())
+int NotificationModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return m_notifications.count();
+}
+
+QVariant NotificationModel::data(const QModelIndex &index, int role) const
+{
+    if (!checkIndex(index, QAbstractItemModel::CheckIndexOption::IndexIsValid)) {
+        return QVariant();
+    }
+
+    const auto &notification = m_notifications.at(index.row());
+
+    switch (role) {
+    case IdRole:
+        return notification.id;
+    case SummaryRole:
+        return notification.summary;
+    case BodyRole:
+        return notification.body;
+    case ActionNamesRole:
+        return notification.actionNames;
+    case ActionLabelsRole:
+        return notification.actionLabels;
+    }
+
     return QVariant();
-
-  if (role == Qt::DisplayRole) {
-    auto data = m_data[index.row()];
-    return QVariant::fromValue(data);
-  }
-  return QVariant();
 }
 
-void NotificationModel::classBegin() {}
-
-void NotificationModel::componentComplete() {
-
-  if (!connection.isConnected()) {
-    return;
-  }
-  connection.registerService(NotificationDbusInterface::Name);
-
-  connection.registerObject(NotificationDbusInterface::Path,
-                            dbusInterface.data(),
-                            QDBusConnection::ExportAllContents);
+QHash<int, QByteArray> NotificationModel::roleNames() const
+{
+    return {
+        {IdRole, QByteArrayLiteral("notificationId")}, // id is a reserved QML keyword.
+        {SummaryRole, QByteArrayLiteral("summary")},
+        {BodyRole, QByteArrayLiteral("body")},
+        {ActionNamesRole, QByteArrayLiteral("actionNames")},
+        {ActionLabelsRole, QByteArrayLiteral("actionLabels")},
+    };
 }
 
-void NotificationModel::dismissed(QString action) {
-  NotificationData *data = qobject_cast<NotificationData *>(sender());
-  auto idx = m_data.indexOf(data);
-  beginRemoveRows(QModelIndex(), idx, idx);
-  m_data.removeAt(idx);
-  endRemoveRows();
+void NotificationModel::dismiss(const QModelIndex &index)
+{
+    if (!checkIndex(index, QAbstractItemModel::CheckIndexOption::IndexIsValid)) {
+        return;
+    }
 
-  emit dbusInterface->ActionInvoked(data->id(), action);
-  emit dbusInterface->NotificationClosed(data->id(),
-                                         NotificationDbusInterface::Dismissed);
+    const auto id = m_notifications.at(index.row()).id;
+
+    beginRemoveRows(QModelIndex(), index.row(), index.row());
+    m_notifications.removeAt(index.row());
+    endRemoveRows();
+
+    Q_EMIT NotificationClosed(id, static_cast<uint>(CloseReason::Dismissed));
 }
 
-unsigned int
-NotificationDbusInterface::Notify(QString app_name, unsigned int replaces_id,
-                                  QString app_icon, QString summary,
-                                  QString body, QStringList actions,
-                                  QVariantMap hints, int expire_timeout) {
-  qDebug() << "got notification " << app_name << replaces_id << app_icon
-           << summary << body << actions << hints << expire_timeout
-           << " ID: " << m_idCounter;
-  auto data = new NotificationData{app_name, replaces_id,    app_icon,
-                                   summary,  body,           actions,
-                                   hints,    expire_timeout, m_idCounter};
-  m_model->Add(data);
-  m_idCounter++;
-  return data->id();
+void NotificationModel::invokeAction(const QModelIndex &index, const QString &action)
+{
+    if (!checkIndex(index, QAbstractItemModel::CheckIndexOption::IndexIsValid)) {
+        return;
+    }
+
+    const auto &notification = m_notifications.at(index.row());
+    Q_ASSERT(notification.actionNames.contains(action));
+
+    Q_EMIT ActionInvoked(notification.id, action);
+    dismiss(index);
 }
 
-QStringList NotificationDbusInterface::GetCapabilities() {
-  return QStringList{
-      "actions", // The server will provide the specified actions to the user.
-      // Even if this cap is missing, actions may still be
-      // specified by the client, however the server is free to
-      // ignore them.
-      "body", // Supports body text. Some implementations may only show the
-              // summary (for instance, onscreen displays, marquee/scrollers)
-  };
-  /*
-      "action-icons", // Supports using icons instead of text for displaying
-                      // actions. Using icons for actions must be enabled on a
-                      // per-notification basis using the "action-icons" hint.
-      "body-hyperlinks", //	The server supports hyperlinks in the
-                         //notifications.
-      "body-images",     //	The server supports images in the notifications.
-      "body-markup",     //	Supports markup in the body text. If marked up
-                     //text is sent to a server that does not give this cap,
-                     //the markup will show through as regular text so must be
-                     //stripped clientside.
-      "icon-multi",  //	The server will render an animation of all the
-                     //frames in a given image array. The client may still
-                     //specify multiple frames even if this cap and/or
-                     //"icon-static" is missing, however the server is free to
-                     //ignore them and use only the primary frame.
-      "icon-static", //	Supports display of exactly 1 frame of any given
-                     //image array. This value is mutually exclusive with
-                     //"icon-multi", it is a protocol error for the server to
-                     //specify both.
-      "persistence", //	The server supports persistence of
-                     //notifications. Notifications will be retained until
-                     //they are acknowledged or removed by the user or
-                     //recalled by the sender. The presence of this capability
-                     //allows clients to depend on the server to ensure a
-                     //notification is seen and eliminate the need for the
-                     //client to display a reminding function (such as a
-                     //status icon) of its own.
-      "sound", // The server supports sounds on notifications. If returned,
-               // the server must support the "sound-file" and
-               // "suppress-sound" hints.
-  */
+uint NotificationModel::Notify(const QString &app_name, uint replaces_id, const QString &app_icon, const QString &summary, const QString &body, const QStringList &actions, const QVariantMap &hints, int timeout)
+{
+    qCDebug(compositorNotification) << "Got notification with summary" << app_name << replaces_id << app_icon << summary << body << actions << hints << timeout;
+
+    Notification notification;
+    notification.id = ++m_idCounter;
+    if (!notification.id) { // Never return zero from this call.
+        ++notification.id;
+    }
+
+    notification.summary = summary;
+    notification.body = body;
+
+    if (actions.count() % 2 != 0) {
+        qCWarning(compositorNotification) << "Received an odd number of actions, this is a client bug:" << actions;
+    } else {
+        notification.actionNames.reserve(actions.count() / 2);
+        notification.actionLabels.reserve(actions.count() / 2);
+        // Actions are pairs of name - label.
+        for (int i = 0; i < actions.count(); i += 2) {
+            const auto &name = actions.at(i);
+            const auto &label = actions.at(i + 1);
+            notification.actionNames.append(name);
+            notification.actionLabels.append(label);
+        }
+    }
+
+    if (replaces_id) {
+        auto it = std::find_if(m_notifications.cbegin(), m_notifications.cend(), [replaces_id](const Notification &notification) {
+            return notification.id == replaces_id;
+        });
+
+        if (it != m_notifications.cend()) {
+            const auto row = std::distance(m_notifications.cbegin(), it);
+
+            notification.id = replaces_id;
+
+            m_notifications[row] = notification;
+            const QModelIndex idx = index(row, 0);
+            Q_EMIT dataChanged(idx, idx);
+
+            return notification.id;
+        } else {
+            qCWarning(compositorNotification) << "Don't know notification id" << replaces_id << "to replace, issuing new notification, this is a client bug.";
+        }
+    }
+
+    beginInsertRows(QModelIndex(), m_notifications.count(), m_notifications.count());
+    m_notifications.append(notification);
+    endInsertRows();
+
+    return notification.id;
 }
 
-void NotificationData::dismiss(QString action) { emit dismissed(action); }
+void NotificationModel::CloseNotification(uint id)
+{
+    qCDebug(compositorNotification) << "Close notification requested for" << id;
 
-unsigned int NotificationModel::count() const { return m_data.count(); }
+    auto it = std::find_if(m_notifications.cbegin(), m_notifications.cend(), [id](const Notification &notification) {
+        return notification.id == id;
+    });
+
+    if (it == m_notifications.cend()) {
+        return;
+    }
+
+    const auto row = std::distance(m_notifications.cbegin(), it);
+
+    beginRemoveRows(QModelIndex(), row, row);
+    m_notifications.removeAt(row);
+    endRemoveRows();
+
+    Q_EMIT NotificationClosed(it->id, static_cast<uint>(CloseReason::Revoked));
+}
+
+QStringList NotificationModel::GetCapabilities() const
+{
+    return QStringList{
+        QStringLiteral("actions"), // The server will provide the specified actions to the user.
+        // Even if this cap is missing, actions may still be
+        // specified by the client, however the server is free to
+        // ignore them.
+        QStringLiteral("body"), // Supports body text. Some implementations may only show the
+                // summary (for instance, onscreen displays, marquee/scrollers)
+    };
+    /*
+        "action-icons", // Supports using icons instead of text for displaying
+                        // actions. Using icons for actions must be enabled on a
+                        // per-notification basis using the "action-icons" hint.
+        "body-hyperlinks", //	The server supports hyperlinks in the
+                           //notifications.
+        "body-images",     //	The server supports images in the notifications.
+        "body-markup",     //	Supports markup in the body text. If marked up
+                       //text is sent to a server that does not give this cap,
+                       //the markup will show through as regular text so must be
+                       //stripped clientside.
+        "icon-multi",  //	The server will render an animation of all the
+                       //frames in a given image array. The client may still
+                       //specify multiple frames even if this cap and/or
+                       //"icon-static" is missing, however the server is free to
+                       //ignore them and use only the primary frame.
+        "icon-static", //	Supports display of exactly 1 frame of any given
+                       //image array. This value is mutually exclusive with
+                       //"icon-multi", it is a protocol error for the server to
+                       //specify both.
+        "persistence", //	The server supports persistence of
+                       //notifications. Notifications will be retained until
+                       //they are acknowledged or removed by the user or
+                       //recalled by the sender. The presence of this capability
+                       //allows clients to depend on the server to ensure a
+                       //notification is seen and eliminate the need for the
+                       //client to display a reminding function (such as a
+                       //status icon) of its own.
+        "sound", // The server supports sounds on notifications. If returned,
+                 // the server must support the "sound-file" and
+                 // "suppress-sound" hints.
+    */
+}
+
+QString NotificationModel::GetServerInformation(QString &vendor, QString &version, QString &spec_version) const
+{
+    vendor = QStringLiteral("EmbeddedCompositor");
+    version = QStringLiteral("0.0.0.1");
+    spec_version = QStringLiteral("1.2");
+    return QStringLiteral("EmbeddedCompositor"); // name
+}

--- a/compositor/notificationmodel.h
+++ b/compositor/notificationmodel.h
@@ -3,139 +3,81 @@
 #ifndef NOTIFICATIONMODEL_H
 #define NOTIFICATIONMODEL_H
 
-#include <QAbstractItemModel>
-
-#include <QDBusConnection>
-#include <QDBusError>
+#include <QAbstractListModel>
+#include <QLoggingCategory>
 #include <QQmlParserStatus>
+#include <QVector>
 
-class NotificationModel;
+Q_DECLARE_LOGGING_CATEGORY(compositorNotification);
 
-class NotificationDbusInterface : public QObject {
-
-  Q_OBJECT
-#define IFACE_STR "org.freedesktop.Notifications"
-  Q_CLASSINFO("D-Bus Interface", IFACE_STR)
-
-  NotificationModel *m_model;
-  unsigned int m_idCounter = 1;
-
-public:
-  enum CloseReason {
-    Expired = 1,
-    Dismissed = 2,
-    CloseCall = 3,
-    UndefinedReserved = 4
-  };
-
-  static constexpr auto Interface = IFACE_STR;
-  static constexpr auto Name = IFACE_STR;
-  static constexpr auto Path = "/org/freedesktop/Notifications";
-  NotificationDbusInterface(NotificationModel *model) : m_model(model) {}
-
-public slots:
-
-  unsigned int Notify(QString app_name, unsigned int replaces_id,
-                      QString app_icon, QString summary, QString body,
-                      QStringList actions, QVariantMap hints,
-                      int expire_timeout);
-  QStringList GetCapabilities();
-
-  void GetServerInformation(QString &name, QString &vendor, QString &version,
-                            QString &spec_version) {
-    name = "EmbeddedCompositor";
-    vendor = "EmbeddedCompositor";
-    version = "0.0.0.1";
-    spec_version = "1.2";
-  }
-signals:
-  void NotificationClosed(unsigned int id, unsigned int reason);
-  void ActionInvoked(unsigned int id, QString action_key);
-  void ActivationToken(unsigned int id, QString activation_token);
+struct Notification
+{
+    uint id = 0;
+    QString summary;
+    QString body;
+    QStringList actionNames;
+    QStringList actionLabels;
 };
+Q_DECLARE_TYPEINFO(Notification, Q_MOVABLE_TYPE);
 
-class NotificationData : public QObject {
-  Q_OBJECT
-  QString m_appName;
-  QString m_appIcon;
-  QString m_summary;
-  QString m_body;
-  QStringList m_actions;
-  QVariantMap m_hints;
-  unsigned int m_replacesId;
-  int m_expireTimeout;
-  unsigned int m_id;
-  Q_PROPERTY(QString appName READ appName NOTIFY dataChanged)
-  Q_PROPERTY(unsigned int replacesId READ replacesId NOTIFY dataChanged)
-  Q_PROPERTY(QString appIcon READ appIcon NOTIFY dataChanged)
-  Q_PROPERTY(QString summary READ summary NOTIFY dataChanged)
-  Q_PROPERTY(QString body READ body NOTIFY dataChanged)
-  Q_PROPERTY(QStringList actions READ actions NOTIFY dataChanged)
-  Q_PROPERTY(QVariantMap hints READ hints NOTIFY dataChanged)
-  Q_PROPERTY(int expireTimeout READ expireTimeout NOTIFY dataChanged)
-  Q_PROPERTY(unsigned int id READ id NOTIFY dataChanged)
+class NotificationModel : public QAbstractListModel, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+    Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
 
 public:
-  NotificationData(QString appName, unsigned int replacesId, QString appIcon,
-                   QString summary, QString body, QStringList actions,
-                   QVariantMap hints, int expireTimeout, unsigned int id)
-      : m_appName(appName), m_appIcon(appIcon), m_summary(summary),
-        m_body(body), m_actions(actions), m_hints(hints),
-        m_replacesId(replacesId), m_expireTimeout(expireTimeout), m_id(id) {}
+    NotificationModel(QObject *parent = nullptr);
+    ~NotificationModel() override = default;
 
-  ~NotificationData() override {}
+    enum Roles {
+        SummaryRole = Qt::DisplayRole,
+        IdRole = Qt::UserRole,
+        BodyRole,
+        ActionNamesRole,
+        ActionLabelsRole
+    };
+    Q_ENUM(Roles)
 
-  const QString &appName() const { return m_appName; }
-  unsigned int replacesId() const { return m_replacesId; }
-  const QString &appIcon() const { return m_appIcon; }
-  const QString &summary() const { return m_summary; }
-  const QString &body() const { return m_body; }
-  const QStringList &actions() const { return m_actions; }
-  const QVariantMap &hints() const { return m_hints; }
-  int expireTimeout() const { return m_expireTimeout; }
-  unsigned int id() const { return m_id; }
+    enum class CloseReason {
+        Expired = 1,
+        Dismissed = 2,
+        Revoked = 3
+    };
 
-public slots:
-  void dismiss(QString action);
-signals:
-  void dataChanged();
-  void timeout();
-  void dismissed(QString action);
-};
+    bool valid() const;
+    Q_SIGNAL void validChanged();
 
-class NotificationModel : public QAbstractListModel, public QQmlParserStatus {
-  Q_OBJECT
-  QScopedPointer<NotificationDbusInterface> dbusInterface;
-  QDBusConnection connection;
-  QList<NotificationData *> m_data;
-  Q_PROPERTY(unsigned int count READ count NOTIFY countChanged)
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
 
-public:
-  Q_INTERFACES(QQmlParserStatus)
-  explicit NotificationModel(QObject *parent = nullptr);
-  virtual ~NotificationModel() override;
+    void classBegin() override;
+    void componentComplete() override;
 
-  void Add(NotificationData *data);
-  int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    Q_INVOKABLE void dismiss(const QModelIndex &index);
+    Q_INVOKABLE void invokeAction(const QModelIndex &index, const QString &action);
 
-  QVariant data(const QModelIndex &index,
-                int role = Qt::DisplayRole) const override;
+    // DBus
+    uint Notify(const QString &app_name, uint replaces_id, const QString &app_icon, const QString &summary, const QString &body, const QStringList &actions, const QVariantMap &hints, int timeout);
+    void CloseNotification(uint id);
+    QStringList GetCapabilities() const;
+    QString GetServerInformation(QString &vendor, QString &version, QString &spec_version) const;
 
-  QHash<int, QByteArray> roleNames() const override {
-    QHash<int, QByteArray> roles;
-    roles[Qt::DisplayRole] = "data";
-    return roles;
-  }
+Q_SIGNALS:
+    void countChanged();
 
-  void classBegin() override;
-  void componentComplete() override;
-  unsigned int count() const;
+    // DBus
+    void ActionInvoked(uint id, const QString &action_key);
+    void ActivationToken(uint id, const QString &activation_token);
+    void NotificationClosed(uint id, uint reason);
 
-signals:
-  void countChanged();
-
-private slots:
-  void dismissed(QString action);
+private:
+    QVector<Notification> m_notifications;
+    uint m_idCounter = 0;
+    bool m_valid = false;
 };
 
 #endif // NOTIFICATIONMODEL_H

--- a/compositor/qml/Notifications/Notification.qml
+++ b/compositor/qml/Notifications/Notification.qml
@@ -5,7 +5,15 @@ import com.embeddedcompositor.dbus 1.0
 
 Rectangle {
     id: notificationRoot
-    property NotificationData notification: model.data
+
+    signal dismissed
+    signal actionInvoked(string action)
+
+    required property string summary
+    required property string body
+    required property var actionNames
+    required property var actionLabels
+
     color: "#202040"
     Rectangle {
         id: header
@@ -17,10 +25,10 @@ Rectangle {
         }
         height: 32
         Text {
-            text: notification.summary
             color:"white"
             anchors.centerIn: parent
             font.pixelSize: 32
+            text: notificationRoot.summary
         }
         color: "#404060"
     }
@@ -37,7 +45,7 @@ Rectangle {
 
         Text {
             font.pixelSize: 24
-            text: notification.body
+            text: notificationRoot.body
             color: "#d0d0d0"
             anchors {
                 top: parent.top
@@ -59,13 +67,13 @@ Rectangle {
             width: parent.width
             spacing: 10
             Repeater {
-                model: notification.actions.length
+                id: actionsRepeater
+                model: notificationRoot.actionNames
                 delegate: MouseArea {
-                    property var action: notification.actions[model.index];
                     width:200
                     height:parent.height
                     onPressed: {
-                        notification.dismiss(action)
+                        notificationRoot.actionInvoked(modelData)
                     }
 
                     Rectangle {
@@ -79,18 +87,17 @@ Rectangle {
                             baselineOffset: font.pixelSize/2
                             horizontalCenter: parent.horizontalCenter
                         }
-                        text: action
+                        text: notificationRoot.actionLabels[index]
                         font.pixelSize:32
                     }
                 }
             }
             MouseArea {
-                visible: notification.actions.length === 0
-                property var action: notification.actions[model.index];
+                visible: actionsRepeater.count === 0
                 width:200
                 height:parent.height
                 onPressed: {
-                    notification.dismiss("")
+                    notificationRoot.dismissed()
                 }
 
                 Rectangle {

--- a/compositor/qml/Notifications/Notifications.qml
+++ b/compositor/qml/Notifications/Notifications.qml
@@ -25,26 +25,23 @@ Rectangle {
         spacing: 1
         model: notifications
         delegate: Notification {
-            property var idx: model.index
-            Component.onCompleted: {
-                if(idx <= 0) {
-                    state = "expanded"
-                }
-            }
+            required property int index
 
-            onIdxChanged: {
-                if(idx <= 0) { // while being in removed animation it is -1
-                    state = "expanded"
-                } else {
-                    state = "shade"
-                }
+            state: index <= 0 ? "expanded" : "shade"
+
+            onDismissed: {
+                const idx = notifications.index(index, 0);
+                notifications.dismiss(idx);
             }
-            state: "shade"
+            onActionInvoked: (action) => {
+                const idx = notifications.index(index, 0);
+                notifications.invokeAction(idx, action);
+            }
 
             width: ListView.view.width
             Text {
                 color: "white"
-                text:  idx +" "+parent.state
+                text:  index +" "+parent.state
             }
         }
 

--- a/compositor/qml/main.qml
+++ b/compositor/qml/main.qml
@@ -257,7 +257,9 @@ WaylandCompositor {
         onCloseRequested: taskSwitcherLoader.item.close();
     }
     GlobalOverlayInterface {
-        onShowRequested: globalOverlay.show(message)
+        onShowRequested: (message) => {
+            globalOverlay.show(message);
+        }
         onHideRequested: globalOverlay.hide()
     }
     CompositorScreenInterface {

--- a/dbus/com.embeddedcompositor.globaloverlay.xml
+++ b/dbus/com.embeddedcompositor.globaloverlay.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+<interface name="com.embeddedcompositor.globaloverlay">
+
+<method name="Show">
+    <arg name="message" type="s" direction="in"/>
+</method>
+
+<method name="Hide"/>
+
+</interface>
+</node>

--- a/dbus/com.embeddedcompositor.screen.xml
+++ b/dbus/com.embeddedcompositor.screen.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+<interface name="com.embeddedcompositor.screen">
+
+<property name="orientation" type="s" access="readwrite"/>
+
+</interface>
+</node>

--- a/dbus/com.embeddedcompositor.taskswitcher.xml
+++ b/dbus/com.embeddedcompositor.taskswitcher.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+<interface name="com.embeddedcompositor.taskswitcher">
+
+<method name="Open"/>
+<method name="Close"/>
+
+</interface>
+</node>

--- a/dbus/org.freedesktop.Notifications.xml
+++ b/dbus/org.freedesktop.Notifications.xml
@@ -1,0 +1,41 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.Notifications">
+    <signal name="NotificationClosed">
+      <arg name="id" type="u" direction="out"/>
+      <arg name="reason" type="u" direction="out"/>
+    </signal>
+    <signal name="ActionInvoked">
+      <arg name="id" type="u" direction="out"/>
+      <arg name="action_key" type="s" direction="out"/>
+    </signal>
+    <signal name="ActivationToken">
+      <arg name="id" type="u" direction="out"/>
+      <arg name="activation_token" type="s" direction="out"/>
+    </signal>
+    <method name="Notify">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In6" value="QVariantMap"/>
+      <arg type="u" direction="out"/>
+      <arg name="app_name" type="s" direction="in"/>
+      <arg name="replaces_id" type="u" direction="in"/>
+      <arg name="app_icon" type="s" direction="in"/>
+      <arg name="summary" type="s" direction="in"/>
+      <arg name="body" type="s" direction="in"/>
+      <arg name="actions" type="as" direction="in"/>
+      <arg name="hints" type="a{sv}" direction="in"/>
+      <arg name="timeout" type="i" direction="in"/>
+    </method>
+    <method name="CloseNotification">
+      <arg name="id" type="u" direction="in"/>
+    </method>
+    <method name="GetCapabilities">
+      <arg type="as" name="caps" direction="out"/>
+    </method>
+    <method name="GetServerInformation">
+      <arg type="s" name="name" direction="out"/>
+      <arg type="s" name="vendor" direction="out"/>
+      <arg type="s" name="version" direction="out"/>
+      <arg type="s" name="spec_version" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/testclients/bottomclient/bottomclient.pro
+++ b/testclients/bottomclient/bottomclient.pro
@@ -7,5 +7,11 @@ RESOURCES += qml.qrc
 
 include(../common.pri)
 
+DBUS_INTERFACES += \
+    ../../dbus/com.embeddedcompositor.globaloverlay.xml \
+    ../../dbus/com.embeddedcompositor.screen.xml \
+    ../../dbus/com.embeddedcompositor.taskswitcher.xml \
+    ../../dbus/org.freedesktop.Notifications.xml
+
 HEADERS += \
     dbusclient.h

--- a/testclients/bottomclient/dbusclient.h
+++ b/testclients/bottomclient/dbusclient.h
@@ -3,43 +3,39 @@
 #ifndef DBUSCLIENT_H
 #define DBUSCLIENT_H
 
-#include <QDebug>
 #include <QObject>
-#include <QtDBus/QDBusInterface>
 
-class DBusClient : public QObject {
-  Q_OBJECT
-  QDBusInterface taskSwitcher{"com.basyskom.embeddedcompositor",
-                              "/taskswitcher",
-                              "com.embeddedcompositor.taskswitcher"};
+#include "globaloverlay_interface.h"
+#include "notifications_interface.h"
+#include "screen_interface.h"
+#include "taskswitcher_interface.h"
 
-  QDBusInterface globalOverlay{"com.basyskom.embeddedcompositor",
-                               "/globaloverlay",
-                               "com.embeddedcompositor.globaloverlay"};
-
-  QDBusInterface compositorScreen{"com.basyskom.embeddedcompositor", "/screen",
-                                  "com.embeddedcompositor.screen"};
-
-  QDBusInterface notifications{"org.freedesktop.Notifications",
-                               "/org/freedesktop/Notifications",
-                               "org.freedesktop.Notifications"};
+class DBusClient : public QObject
+{
+    Q_OBJECT
 
 public:
-  explicit DBusClient(QObject *parent = nullptr);
-  Q_INVOKABLE void openTaskSwitcher() { taskSwitcher.call("Open"); }
-  Q_INVOKABLE void closeTaskSwitcher() { taskSwitcher.call("Close"); }
-  Q_INVOKABLE void showGlobalOverlay(QString message) {
-    globalOverlay.call("Show", message);
-  }
-  Q_INVOKABLE void hideGlobalOverlay() { globalOverlay.call("Hide"); }
-  Q_INVOKABLE uint notify(QString summary, QString body, QStringList actions);
+    explicit DBusClient(QObject *parent = nullptr);
+    ~DBusClient() override = default;
 
-  Q_INVOKABLE void setOrientation(QString orientation) {
-    compositorScreen.setProperty("orientation", orientation);
-  }
-signals:
-  void notificationActionInvoked(unsigned int id, QString action);
-  void notificationClosed(unsigned int id, unsigned int);
+    Q_INVOKABLE void openTaskSwitcher();
+    Q_INVOKABLE void closeTaskSwitcher();
+
+    Q_INVOKABLE void showGlobalOverlay(const QString &message);
+    Q_INVOKABLE void hideGlobalOverlay();
+    Q_INVOKABLE uint notify(const QString &summary, const QString &body, const QStringList &actions);
+
+    Q_INVOKABLE void setOrientation(const QString &orientation);
+
+Q_SIGNALS:
+    void notificationActionInvoked(unsigned int id, const QString &action);
+    void notificationClosed(unsigned int id, unsigned int);
+
+private:
+    org::freedesktop::Notifications m_notificationsIface;
+    com::embeddedcompositor::globaloverlay m_overlayIface;
+    com::embeddedcompositor::screen m_screenIface;
+    com::embeddedcompositor::taskswitcher m_taskSwitcherIface;
 };
 
 #endif // DBUSCLIENT_H


### PR DESCRIPTION
**compositor: Use generated DBus adaptors from protocol XML**

Makes the DBus code more maintainable and stable since the protocol is
explicitly documented in an XML file rather than inferred from class
properties and scriptable slots.

A base `DBusInterface` class is introduced which handles the initialization
so that the actual types exposed to QML (e.g. `TaskSwitcherInterface`)
are very minimalist. Since Qt DBus does not automatically handle the DBus
properties changed signal, code is added to do that manually.

The DBus API itself remains unaltered, clients continue to function
just fine.

Unfortunately, QMake does not allow specifying the parent class for
the generated adaptor (so that it is compile-time checked that all
methods are implemented), necessitating the use of boilerplate flags.

**compositor: Port Notifications model to DBus XML**
                      
This simplifies the code by merging the three classes into one
with DBus outsourced to the generated DBus adaptor.

It also embraces the features of `QAbstractListModel` fully,
with the Notification data no longer exposed as an object to QML
but rather proper model roles being used. The functions on the
notification data are turned into invokables on the model itself
taking a `QModelIndex`.

The model is also made more standards-compliant:

* Actions is a list of pairs of name - label, not a flat
  list of labels
* replaces_id to replace an existing notification is supported,
  to enable using various Notification tester tools for ease
  of development

The notification UI makes use of modern QML language features, such
as `required property` instead of relying on the magic
`model` context property as well as JavaScript functions with
named arguments for signal handlers.

**bottomclient: Use generated DBus interfaces from protocol XML**

Makes the code more maintainable by doing compile-time checked
function calls and signal connections.

Moreover, it is more efficient since the interface is known
whereas `QDBusInterface` does a blocking introspection of the
service in its constructor.

Also make the actions passed to the notification service
standards-compliant by supplying a list of name - label pairs.